### PR TITLE
Add "missing" port mappings

### DIFF
--- a/helm/jaeger-all-in-one/templates/deployment.yaml
+++ b/helm/jaeger-all-in-one/templates/deployment.yaml
@@ -54,9 +54,20 @@ spec:
             - name: http-ui
               containerPort: 16686
               protocol: TCP
+            - name: grpc-proto
+              containerPort: 14250
+              protocol: TCP
+            - name: http-bin-thr
+              containerPort: 14268
+              protocol: TCP
             - name: http-admin
               containerPort: 14269
               protocol: TCP
+            {{- if .Values.enableHttpZipkinCollector }}
+            - name: http-zipkin
+              containerPort: 9411
+              protocol: TCP
+            {{- end }}  
           {{- if .Values.volume.enabled }}
           volumeMounts:
             - mountPath: "/badger"
@@ -77,6 +88,10 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
+          {{- if .Values.enableHttpZipkinCollector }}
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            value: "9411"
+          {{- end }}  
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/jaeger-all-in-one/templates/service.yaml
+++ b/helm/jaeger-all-in-one/templates/service.yaml
@@ -32,10 +32,24 @@ spec:
       targetPort: http-ui
       protocol: TCP
       name: http-ui
+    - port: 14250
+      targetPort: grpc-proto
+      protocol: TCP
+      name: grpc-proto
+    - port: 14268
+      targetPort: http-bin-thr
+      protocol: TCP
+      name: http-bin-thr
     - port: 14269
       targetPort: http-admin
       protocol: TCP
       name: http-admin
+    {{- if .Values.enableHttpZipkinCollector }}
+    - port: 9411
+      targetPort: http-zipkin
+      protocol: TCP
+      name: http-zipkin
+    {{- end }}  
   selector:
     {{- include "jaeger-all-in-one.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/jaeger-all-in-one/values.yaml
+++ b/helm/jaeger-all-in-one/values.yaml
@@ -29,17 +29,15 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podAnnotations:
+podAnnotations: 
   prometheus.io/scrape: "true"
   prometheus.io/path: "/metrics"
   prometheus.io/port: "14269"
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -56,25 +54,21 @@ service:
 
 ingress:
   enabled: false
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # cert-manager.io/cluster-issuer: letsencrypt
     # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     # nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
-  hosts:
-    []
+  hosts: []
     # - host: jaeger.localhost
-    #   paths:
+    #   paths: 
     #     - /
-  tls:
-    []
+  tls: []
     # - secretName: tls-secret
     #   hosts:
     #     - jaeger.localhost
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/helm/jaeger-all-in-one/values.yaml
+++ b/helm/jaeger-all-in-one/values.yaml
@@ -20,6 +20,8 @@ environmentVariables:
   BADGER_DIRECTORY_VALUE: /badger/data
   BADGER_DIRECTORY_KEY: /badger/key
 
+enableHttpZipkinCollector: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -27,15 +29,17 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podAnnotations: 
+podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/path: "/metrics"
   prometheus.io/port: "14269"
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -52,21 +56,25 @@ service:
 
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # cert-manager.io/cluster-issuer: letsencrypt
     # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     # nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
-  hosts: []
+  hosts:
+    []
     # - host: jaeger.localhost
-    #   paths: 
+    #   paths:
     #     - /
-  tls: []
+  tls:
+    []
     # - secretName: tls-secret
     #   hosts:
     #     - jaeger.localhost
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
This commit adds more of Jaegers exposed ports to the service object and adds
support for activating Jaegers zipkin collector which is disabled by default.

More information about the collectors can be found here:
https://www.jaegertracing.io/docs/1.21/deployment/#collectors

And the Environment variable for Zipkin HTTP can be found here:
https://www.jaegertracing.io/docs/1.21/getting-started/#all-in-one