### PR TITLE
Fixed zipkin http config problem

### DIFF
--- a/helm/jaeger-all-in-one/templates/deployment.yaml
+++ b/helm/jaeger-all-in-one/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- if .Values.enableHttpZipkinCollector }}
-          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+          - name: COLLECTOR_ZIPKIN_HOST_PORT
             value: "9411"
           {{- end }}  
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Wrong env variable is used to enable zipkin port exposure, see also https://www.jaegertracing.io/docs/1.22/getting-started/

You can nicely see in the startup logs if the jaeger is listening for zipkin traffic. When having `enableHttpZipkinCollector: true`, that message is telling that it is not listening.

With my change of using COLLECTOR_ZIPKIN_HOST_PORT variable the startup logs indicate a listening jaeger.

Workaround is to set the env variable additional like:
```
enableHttpZipkinCollector: true
environmentVariables:
  COLLECTOR_ZIPKIN_HOST_PORT: "9411"
```